### PR TITLE
Removed ResetShipGlow and ResetPartGlow methods

### DIFF
--- a/source/DangIt/Failure modules/FailureModule.cs
+++ b/source/DangIt/Failure modules/FailureModule.cs
@@ -422,8 +422,6 @@ namespace ippo
                     if (this.HasFailed)
                         this.DI_Disable();
 
-                    DangIt.ResetShipGlow(this.part.vessel);
-
                 }
 
                 if (DangIt.Instance.CurrentSettings.EnabledForSave)
@@ -624,7 +622,7 @@ namespace ippo
                 this.DI_Disable();
 
                 TimeWarp.SetRate(0, true);      // stop instantly
-                this.SetFailureState(true);     // Sets the failure state, handles the events, handles the glow
+                this.SetFailureState(true);     // Sets the failure state, handles the events
 
                 if (!this.Silent)
                 {
@@ -655,14 +653,13 @@ namespace ippo
 
         /// <summary>
         /// Sets / resets the failure of the part.
-        /// Also resets the ship's glow and sets the event's visibility
+        /// Also sets the event's visibility
         /// </summary>
         protected void SetFailureState(bool state)
         {
             try
             {
                 this.HasFailed = state;
-                DangIt.ResetShipGlow(this.part.vessel);
 
                 Events["Fail"].active = !state;
                 Events["EvaRepair"].active = state;
@@ -726,8 +723,6 @@ namespace ippo
 
                     FindObjectOfType<AlarmManager>().RemoveAllAlarmsForModule(this); //Remove alarms from this module
                 }
-
-                DangIt.ResetShipGlow(this.part.vessel);
 
             }
             catch (Exception e)

--- a/source/DangIt/Runtime/Static.cs
+++ b/source/DangIt/Runtime/Static.cs
@@ -121,54 +121,5 @@ namespace ippo
             return ((idx < 0) ? null : FlightGlobals.Vessels[idx].rootPart);
         }
 
-
-       
-        /// <summary>
-        /// Resets the glow on all the vessel.
-        /// Parts that have failed will glow red unless they are set to fail silently.
-        /// </summary>
-        /// <param name="v"></param>
-        public static float ResetShipGlow(Vessel v)
-        {
-            ResetPartGlow(v.rootPart);
-            
-            return DangIt.Now();
-        }
-
-
-
-        /// <summary>
-        /// Resets the glow on a single part and then recursively on all its children.
-        /// </summary>
-        /// <param name="part"></param>
-        private static void ResetPartGlow(Part part)
-        {
-            // Set the highlight to default
-            part.SetHighlightDefault();
-
-
-            // If the glow is globally disabled, don't even bother looking for failures
-            if (DangIt.Instance.CurrentSettings.Glow)
-            {
-                // Scan all the failure modules, if any
-                List<FailureModule> failModules = part.Modules.OfType<FailureModule>().ToList();
-                for (int i = 0; i < failModules.Count; i++)
-                {
-                    if (failModules[i].HasFailed && !failModules[i].Silent)
-                    {
-                        // If any module has failed, glow red and stop searching (just one is sufficient)
-                        part.SetHighlightColor(Color.red);
-                        part.SetHighlightType(Part.HighlightType.AlwaysOn);
-                        part.SetHighlight(true, false);
-                        break;
-                    }
-                }
-            }
-
-
-            // Reset the glow for all the child parts
-            foreach (Part child in part.children)
-                DangIt.ResetPartGlow(child);
-        }
     }
 }


### PR DESCRIPTION
I suggest to remove **ResetShipGlow()** and **ResetPartGlow()** methods completely. I suppose, the new 'highlighting code' in **FixedUpdate()** totally replaces their functionality, setting proper 'highlighting' state of each part of the vessel at each physical frame (so, there is no use to call these methods anymore, in any place of the code).

P.S. Actually, I'm not a coder and that's my ~~test~~ first pull request, so I apologize in advance for any possible errors :)