### PR TITLE
Changed additional part cost for storage containers. 

### DIFF
--- a/GameData/DangIt/ModuleManager/NoCostForPodStorage.cfg.disabled
+++ b/GameData/DangIt/ModuleManager/NoCostForPodStorage.cfg.disabled
@@ -4,51 +4,51 @@
 
 @PART[*]:HAS[#CrewCapacity[1]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 2520
+	@cost -= 700
 }
 
 @PART[*]:HAS[#CrewCapacity[2]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 5040
+	@cost -= 1400
 }
 
 @PART[*]:HAS[#CrewCapacity[3]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 7560
+	@cost -= 2100
 }
 
 @PART[*]:HAS[#CrewCapacity[4]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 10080
+	@cost -= 2800
 }
 
 @PART[*]:HAS[#CrewCapacity[5]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 12600
+	@cost -= 3500
 }
 
 @PART[*]:HAS[#CrewCapacity[6]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 15120
+	@cost -= 4200
 }
 
 @PART[*]:HAS[#CrewCapacity[7]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 17640
+	@cost -= 4900
 }
 
 @PART[*]:HAS[#CrewCapacity[8]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 20160
+	@cost -= 5000
 }
 
 @PART[Mk1FuselageStructural]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 7560
+	@cost -= 2100
 }
 // Add to all cargo bays
 @PART[*]:HAS[@MODULE[ModuleCargoBay],!MODULE[ModuleProceduralFairing],~name[RadialBay]]:FOR[DangIt]:AFTER[DangIt]
 {
-	@cost -= 7560
+	@cost -= 2100
 }
  

--- a/GameData/DangIt/ModuleManager/SpareParts.cfg
+++ b/GameData/DangIt/ModuleManager/SpareParts.cfg
@@ -17,7 +17,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[1]]
 {
-	@cost += 3150
+	@cost += 700
     RESOURCE
 	{
 		name = SpareParts
@@ -32,7 +32,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[2]]
 {
-	@cost += 6300
+	@cost += 1400
     RESOURCE
 	{
 		name = SpareParts
@@ -47,7 +47,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[3]]
 {
-	@cost += 9450
+	@cost += 2100
     RESOURCE
 	{
 		name = SpareParts
@@ -62,7 +62,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[4]]
 {
-	@cost += 12600
+	@cost += 2800
     RESOURCE
 	{
 		name = SpareParts
@@ -77,7 +77,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[5]]
 {
-	@cost += 15750
+	@cost += 3500
     RESOURCE
 	{
 		name = SpareParts
@@ -92,7 +92,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[6]]
 {
-	@cost += 18900
+	@cost += 4200
     RESOURCE
 	{
 		name = SpareParts
@@ -107,7 +107,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[7]]
 {
-	@cost += 22050
+	@cost += 4900
     RESOURCE
 	{
 		name = SpareParts
@@ -122,7 +122,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[*]:HAS[#CrewCapacity[8]]
 {
-	@cost += 25200
+	@cost += 5000
     RESOURCE
 	{
 		name = SpareParts
@@ -137,7 +137,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 
 @PART[Mk1FuselageStructural]
 {
-	@cost += 9450
+	@cost += 2100
     RESOURCE
 	{
 		name = SpareParts
@@ -152,7 +152,7 @@ RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
 // Add to all cargoe bays
 @PART[*]:HAS[@MODULE[ModuleCargoBay],!MODULE[ModuleProceduralFairing],~name[RadialBay]]
 {
-	@cost += 9450
+	@cost += 2100
     RESOURCE
 	{
 		name = SpareParts

--- a/GameData/DangIt/ModuleManager/SpareParts.cfg
+++ b/GameData/DangIt/ModuleManager/SpareParts.cfg
@@ -4,12 +4,12 @@
 /////////////////////////////////////////////////////////////////
 
 
-RESOURCE_DEFINITION:NEEDS[!CommunityTechTree]
+RESOURCE_DEFINITION:NEEDS[!CommunityResourcePack]
 {
    name = SpareParts
    density = 0.00378
    flowMode = NO_FLOW
-   transfer = NONE
+   transfer = PUMP
    isTweakable = true
    unitCost = 12.6
 }


### PR DESCRIPTION
Lowered additional part cost for storage containers significantly. Storage in command pods and cargobay costs now 14$ per unit of spare parts instead of 63$, making it slightly more expensive compared to the DangIt Repair Bay (12.8$ per unit).
fixed #18 

Additionaly made the resource initiation check for CommunityResourcePack and made SpareParts transferable according to a suggestion by forum user Fulgora